### PR TITLE
Add theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <!-- Reference your unchanged CSS -->
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body class="theme-terminal">
   <!-- Loading Screen -->
   <div id="loadingScreen" class="loading-screen">
     <div class="loader">
@@ -53,6 +53,21 @@
           <option value="llama3-70b-8192">Llama3 70B 8192</option>
           <option value="llama3-8b-8192">Llama3 8B 8192</option>
           <option value="mixtral-8x7b-32768">Mixtral 8x7B 32768</option>
+        </select>
+      </div>
+
+      <!-- Theme Selection -->
+      <div class="theme-selector">
+        <label for="themeSelect">Select Theme:</label>
+        <select id="themeSelect">
+          <option value="terminal">Terminal Green</option>
+          <option value="solarized-light">Solarized Light</option>
+          <option value="solarized-dark">Solarized Dark</option>
+          <option value="midnight">Midnight Blue</option>
+          <option value="lavender">Lavender</option>
+          <option value="forest">Forest</option>
+          <option value="neon">Neon Pink</option>
+          <option value="cyberpunk">Cyberpunk</option>
         </select>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const saveApiKeyBtn = document.getElementById('saveApiKeyBtn');
 const changeApiKeyBtn = document.getElementById('changeApiKeyBtn');
 const loadingScreen = document.getElementById('loadingScreen');
 const modelSelect = document.getElementById('modelSelect');
+const themeSelect = document.getElementById('themeSelect');
 const hamburgerBtn = document.getElementById('hamburgerBtn');
 const hamburgerMenu = document.getElementById('hamburgerMenu');
 const closeBtn = document.querySelector('.close-btn');
@@ -115,6 +116,37 @@ function loadSelectedModel() {
   }
 }
 
+function applyTheme(theme) {
+  document.body.classList.remove(
+    'theme-terminal',
+    'theme-solarized-light',
+    'theme-solarized-dark',
+    'theme-midnight',
+    'theme-lavender',
+    'theme-forest',
+    'theme-neon',
+    'theme-cyberpunk'
+  );
+  document.body.classList.add(`theme-${theme}`);
+}
+
+function loadSelectedTheme() {
+  const savedTheme = localStorage.getItem('selectedTheme');
+  if (savedTheme) {
+    themeSelect.value = savedTheme;
+    applyTheme(savedTheme);
+  } else {
+    themeSelect.value = 'terminal';
+    applyTheme('terminal');
+  }
+}
+
+themeSelect.addEventListener('change', () => {
+  const selectedTheme = themeSelect.value;
+  applyTheme(selectedTheme);
+  localStorage.setItem('selectedTheme', selectedTheme);
+});
+
 modelSelect.addEventListener('change', () => {
   const selectedModel = modelSelect.value;
   localStorage.setItem('selectedModel', selectedModel);
@@ -125,6 +157,7 @@ window.addEventListener('load', () => {
   loadingScreen.style.display = 'none';
   loadApiKey();
   loadSelectedModel();
+  loadSelectedTheme();
   handleInitialRun();
   initializeMutationObserver();
 });

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+/* Theme Variables */
+:root {
+    --bg-color: #000000;
+    --text-color: #00ff00;
+    --hover-bg-color: #003300;
+    --generated-color: #009900;
+}
+
 /* General Styles */
 body {
     display: flex;
@@ -9,17 +17,17 @@ body {
     height: 100vh;
     margin: 0;
     padding: 0;
-    background-color: #000000;
+    background-color: var(--bg-color);
     overflow: hidden; /* Prevent scrollbars due to animated words */
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 h1 {
-    color: #00ff00;
+    color: var(--text-color);
     font-size: 45px; /* Increased font size */
     text-align: center; /* Center the heading */
     margin-bottom: 30px;
-    text-shadow: 0 0 5px #00ff00;
+    text-shadow: 0 0 5px var(--text-color);
 }
 
 .container {
@@ -42,8 +50,8 @@ h1 {
     font-size: 24px; /* Increased font size */
     line-height: 1.6;
     overflow-y: auto;
-    color: #00ff00;
-    background-color: #000000;
+    color: var(--text-color);
+    background-color: var(--bg-color);
     transition: background-color 0.3s;
     box-sizing: border-box; /* Ensure padding doesn't affect total width */
     scroll-behavior: smooth; /* Smooth scrolling */
@@ -53,22 +61,22 @@ h1 {
 
 #editor:focus {
     outline: none;
-    background-color: #000000;
+    background-color: var(--bg-color);
 }
 
 #editor[contenteditable]:empty:before {
     content: attr(placeholder);
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 /* Generated Text Styling */
 
 .generated {
-    color: #009900; /* Initial grey color replaced with darker green */
+    color: var(--generated-color); /* Initial grey color replaced with darker green */
 }
 
 .accepted {
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 /* Hamburger Menu Button Styling */
@@ -77,9 +85,9 @@ h1 {
     bottom: 30px;
     right: 30px;
     padding: 12px 20px;
-    background-color: #000000;
-    color: #00ff00;
-    border: 1px solid #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     cursor: pointer;
     font-size: 24px;
@@ -90,7 +98,7 @@ h1 {
 
 /* Hover effect for Hamburger Menu Button */
 .hamburger-btn:hover {
-    background-color: #003300;
+    background-color: var(--hover-bg-color);
 }
 
 /* Hamburger Menu Styling */
@@ -100,9 +108,9 @@ h1 {
     bottom: 80px; /* Positioned above the hamburger button */
     right: 30px;
     width: 300px;
-    background-color: #000000;
-    color: #00ff00;
-    border: 1px solid #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     z-index: 5; /* Above the hamburger button */
     overflow: hidden;
@@ -114,7 +122,7 @@ h1 {
     font-weight: bold;
     padding: 10px 20px;
     cursor: pointer;
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 .hamburger-menu .close-btn:hover {
@@ -135,32 +143,60 @@ h1 {
     display: block;
     margin-bottom: 8px;
     font-size: 16px;
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 .model-selector select {
     width: 100%;
     padding: 10px;
     font-size: 16px;
-    border: 1px solid #00ff00;
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     outline: none;
     transition: border-color 0.3s;
-    background-color: #000000;
-    color: #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 .model-selector select:focus {
-    border-color: #00ff00;
+    border-color: var(--text-color);
+}
+
+/* Theme Selector Styles */
+.theme-selector {
+    margin-bottom: 20px;
+}
+
+.theme-selector label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 16px;
+    color: var(--text-color);
+}
+
+.theme-selector select {
+    width: 100%;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid var(--text-color);
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.3s;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.theme-selector select:focus {
+    border-color: var(--text-color);
 }
 
 /* API Key Button within Hamburger Menu */
 .menu-button {
     width: 100%;
     padding: 12px;
-    background-color: #000000;
-    color: #00ff00;
-    border: 1px solid #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     font-size: 18px;
     cursor: pointer;
@@ -169,7 +205,7 @@ h1 {
 }
 
 .menu-button:hover {
-    background-color: #003300;
+    background-color: var(--hover-bg-color);
 }
 
 /* Modal Styling */
@@ -186,11 +222,11 @@ h1 {
 }
 
 .modal-content {
-    background-color: #000000;
-    color: #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     margin: 15% auto;
     padding: 40px;
-    border: 1px solid #00ff00;
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     width: 80%;
     max-width: 400px;
@@ -209,24 +245,24 @@ h1 {
     width: 100%;
     padding: 12px 20px;
     margin: 12px 0;
-    border: 1px solid #00ff00;
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     box-sizing: border-box;
     font-size: 16px;
-    background-color: #000000;
-    color: #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 .modal-content input[type="password"]::placeholder {
-    color: #00ff00;
+    color: var(--text-color);
 }
 
 .modal-content button {
     width: 100%;
     padding: 12px;
-    background-color: #000000;
-    color: #00ff00;
-    border: 1px solid #00ff00;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--text-color);
     border-radius: 4px;
     font-size: 18px;
     cursor: pointer;
@@ -235,7 +271,7 @@ h1 {
 }
 
 .modal-content button:hover {
-    background-color: #003300;
+    background-color: var(--hover-bg-color);
 }
 
 .close-modal {
@@ -244,10 +280,67 @@ h1 {
     right: 20px;
     font-size: 28px;
     font-weight: bold;
-    color: #00ff00;
+    color: var(--text-color);
     cursor: pointer;
 }
 
 .close-modal:hover {
     color: #ffffff;
+}
+
+/* ------------------- Theme Definitions ------------------- */
+body.theme-terminal {
+    --bg-color: #000000;
+    --text-color: #00ff00;
+    --hover-bg-color: #003300;
+    --generated-color: #009900;
+}
+
+body.theme-solarized-light {
+    --bg-color: #fdf6e3;
+    --text-color: #657b83;
+    --hover-bg-color: #b58900;
+    --generated-color: #586e75;
+}
+
+body.theme-solarized-dark {
+    --bg-color: #002b36;
+    --text-color: #93a1a1;
+    --hover-bg-color: #586e75;
+    --generated-color: #839496;
+}
+
+body.theme-midnight {
+    --bg-color: #001f3f;
+    --text-color: #7FDBFF;
+    --hover-bg-color: #005577;
+    --generated-color: #39CCCC;
+}
+
+body.theme-lavender {
+    --bg-color: #F2E5FF;
+    --text-color: #6930C3;
+    --hover-bg-color: #B284BE;
+    --generated-color: #5E548E;
+}
+
+body.theme-forest {
+    --bg-color: #013220;
+    --text-color: #A3E4B5;
+    --hover-bg-color: #025732;
+    --generated-color: #66cdaa;
+}
+
+body.theme-neon {
+    --bg-color: #000000;
+    --text-color: #ff26a1;
+    --hover-bg-color: #33001a;
+    --generated-color: #ff47c0;
+}
+
+body.theme-cyberpunk {
+    --bg-color: #111111;
+    --text-color: #00FFFF;
+    --hover-bg-color: #004d4d;
+    --generated-color: #80ffff;
 }


### PR DESCRIPTION
## Summary
- add a theme dropdown to the menu
- define 8 themes including the original terminal one
- use CSS variables for colors
- persist the chosen theme in localStorage and load it on start

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f710f435483238ae026f297eaec2f