### PR TITLE
Add word count display

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
   <div class="container">
     <h1>just.<b>type</b></h1>
     <div id="editor" contenteditable="true" placeholder="Start typing..."></div>
+    <div id="wordCount">Word Count: 0</div>
   </div>
 
   <!-- Hamburger Menu Button -->

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ const hamburgerBtn = document.getElementById('hamburgerBtn');
 const hamburgerMenu = document.getElementById('hamburgerMenu');
 const closeBtn = document.querySelector('.close-btn');
 const closeModalBtn = document.querySelector('.close-modal');
+const wordCountDisplay = document.getElementById('wordCount');
 
 let typingTimer;
 const doneTypingInterval = 1000; // 1 second
@@ -236,7 +237,11 @@ function initializeMutationObserver() {
 editor.addEventListener('input', () => {
   if (!userIsTyping) return;
   clearTimeout(typingTimer);
-  const words = editor.innerText.trim().split(/\s+/);
+  const text = editor.innerText.trim();
+  const words = text ? text.split(/\s+/) : [];
+  if (wordCountDisplay) {
+    wordCountDisplay.textContent = `Word Count: ${words.length}`;
+  }
   if (words.length >= 3 && !isGenerating) {
     typingTimer = setTimeout(generateNextSentence, doneTypingInterval);
   }

--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,14 @@ h1 {
     color: var(--text-color);
 }
 
+/* Word Count Display */
+#wordCount {
+    margin-top: 10px;
+    font-size: 18px;
+    text-align: right;
+    color: var(--text-color);
+}
+
 /* Hamburger Menu Button Styling */
 .hamburger-btn {
     position: fixed;


### PR DESCRIPTION
## Summary
- show current word count underneath the editor
- style the word count area
- update editor input handler to refresh the word count

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_683ff4e17d308323a46d1157976f2127