### PR TITLE
Add customizable system prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,12 @@
         </select>
       </div>
 
+      <!-- System Prompt -->
+      <div class="prompt-config">
+        <label for="systemPrompt">System Prompt:</label>
+        <textarea id="systemPrompt" rows="4" placeholder="Enter system prompt"></textarea>
+      </div>
+
       <!-- API Key Button within Hamburger Menu -->
       <button id="changeApiKeyBtn" class="menu-button">API KEY</button>
 

--- a/script.js
+++ b/script.js
@@ -11,6 +11,10 @@ const hamburgerBtn = document.getElementById('hamburgerBtn');
 const hamburgerMenu = document.getElementById('hamburgerMenu');
 const closeBtn = document.querySelector('.close-btn');
 const closeModalBtn = document.querySelector('.close-modal');
+const systemPromptInput = document.getElementById('systemPrompt');
+
+const DEFAULT_SYSTEM_PROMPT =
+  'You are a helpful assistant that generates the next sentence based on the given text. Max 20 words. Respond with only the next sentence and never start with a capitalized first word unless it is "I" or a proper noun.';
 
 let typingTimer;
 const doneTypingInterval = 1000; // 1 second
@@ -72,6 +76,19 @@ function loadApiKey() {
     openApiModal();
   }
 }
+
+function loadSystemPrompt() {
+  const savedPrompt = localStorage.getItem('systemPrompt');
+  if (savedPrompt) {
+    systemPromptInput.value = savedPrompt;
+  } else {
+    systemPromptInput.value = DEFAULT_SYSTEM_PROMPT;
+  }
+}
+
+systemPromptInput.addEventListener('change', () => {
+  localStorage.setItem('systemPrompt', systemPromptInput.value);
+});
 
 saveApiKeyBtn.addEventListener('click', () => {
   const apiKey = modalApiKeyInput.value.trim();
@@ -158,6 +175,7 @@ window.addEventListener('load', () => {
   loadApiKey();
   loadSelectedModel();
   loadSelectedTheme();
+  loadSystemPrompt();
   handleInitialRun();
   initializeMutationObserver();
 });
@@ -307,6 +325,8 @@ async function generateNextSentence() {
     const entireText = text;
 
     // Example: Adjust to your actual endpoint and request shape
+    const systemPrompt = localStorage.getItem('systemPrompt') || DEFAULT_SYSTEM_PROMPT;
+
     const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -318,10 +338,7 @@ async function generateNextSentence() {
         messages: [
           {
             role: 'system',
-            content:
-              'You are a helpful assistant that generates the next sentence based on the given text. ' +
-              'Max 20 words. Respond with only the next sentence and never start with a capitalized first ' +
-              'word unless it is "I" or a proper noun.',
+            content: systemPrompt,
           },
           { role: 'user', content: entireText },
         ],

--- a/styles.css
+++ b/styles.css
@@ -190,6 +190,35 @@ h1 {
     border-color: var(--text-color);
 }
 
+/* System Prompt Config */
+.prompt-config {
+    margin-bottom: 20px;
+}
+
+.prompt-config label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 16px;
+    color: var(--text-color);
+}
+
+.prompt-config textarea {
+    width: 100%;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid var(--text-color);
+    border-radius: 4px;
+    outline: none;
+    resize: vertical;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'VT323', 'Courier New', Courier, monospace;
+}
+
+.prompt-config textarea:focus {
+    border-color: var(--text-color);
+}
+
 /* API Key Button within Hamburger Menu */
 .menu-button {
     width: 100%;


### PR DESCRIPTION
## Summary
- add textarea in the hamburger menu for changing the system prompt
- remember the custom prompt in `localStorage`
- apply saved prompt when sending the API request
- style new prompt configuration field

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_683ff4e0b8a48323845c68df15ff419f