### PR TITLE
Implement new features and playful modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
   <div class="container">
     <h1>just.<b>type</b></h1>
     <div id="editor" contenteditable="true" placeholder="Start typing..."></div>
+    <div id="wordCount" class="word-count">0 words</div>
   </div>
 
   <!-- Hamburger Menu Button -->
@@ -55,6 +56,7 @@
           <option value="mixtral-8x7b-32768">Mixtral 8x7B 32768</option>
         </select>
       </div>
+      <div id="modelInfo" class="model-info"></div>
 
       <!-- Theme Selection -->
       <div class="theme-selector">
@@ -70,6 +72,18 @@
           <option value="cyberpunk">Cyberpunk</option>
         </select>
       </div>
+
+      <textarea id="promptInput" class="prompt-input" placeholder="System prompt..."></textarea>
+
+      <label class="toggle">
+        <input type="checkbox" id="chaosToggle" /> Chaos Mode
+      </label>
+      <label class="toggle">
+        <input type="checkbox" id="voiceToggle" /> Voice Mode
+      </label>
+
+      <button id="asciiBtn" class="menu-button">ASCII Summary</button>
+      <button id="downloadBtn" class="menu-button">Download Text</button>
 
       <!-- API Key Button within Hamburger Menu -->
       <button id="changeApiKeyBtn" class="menu-button">API KEY</button>

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,41 @@ h1 {
     font-family: 'VT323', 'Courier New', Courier, monospace;
 }
 
+/* Word Count Display */
+.word-count {
+    margin-top: 10px;
+    font-size: 18px;
+    text-align: right;
+}
+
+/* Model Info Display */
+.model-info {
+    margin-bottom: 20px;
+    font-size: 14px;
+    color: var(--text-color);
+}
+
+/* Prompt Input */
+.prompt-input {
+    width: 100%;
+    height: 80px;
+    margin-bottom: 20px;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid var(--text-color);
+    border-radius: 4px;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'VT323', 'Courier New', Courier, monospace;
+}
+
+/* Toggle labels */
+.toggle {
+    display: block;
+    margin-bottom: 10px;
+    font-size: 16px;
+}
+
 /* Model Selector Styles within Hamburger Menu */
 .model-selector {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- autosave editor contents between sessions
- let users download their text
- add customizable system prompt
- display model info
- show live word count
- add chaos mode, voice playback, ASCII summary and Easter egg

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_683ff4041ea88323b5eaeb6f39afe5ec