### PR TITLE
Add loading screen styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,44 @@ h1 {
     z-index: 1;
 }
 
+/* Loading Screen */
+.loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    z-index: 10;
+}
+
+.loading-screen.hidden {
+    display: none;
+}
+
+.loader {
+    text-align: center;
+}
+
+.spinner {
+    width: 50px;
+    height: 50px;
+    border: 4px solid var(--text-color);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 20px;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 /* Editor Styles */
 #editor {
     width: 100%; /* Responsive width */


### PR DESCRIPTION
## Summary
- add `.loading-screen`, `.loader` and `.spinner` styles
- include keyframe animation for rotating spinner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffe395ba48323b4ee2aae432c5e11