### PR TITLE
Fix visuals shader precision for WebGL

### DIFF
--- a/script.js
+++ b/script.js
@@ -270,6 +270,9 @@ function initializeVisualsApp() {
   `;
 
   const fragmentShader = `
+    precision mediump float;
+    precision mediump int;
+
     uniform float u_time;
     uniform float u_resolution_x;
     uniform float u_resolution_y;


### PR DESCRIPTION
## Summary
- define default float and int precision at the top of the visuals fragment shader so it compiles on WebGL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc6847519c8323bdb2b18bd81ce673