### PR TITLE
Normalize clump noise value for shader threshold

### DIFF
--- a/script.js
+++ b/script.js
@@ -322,7 +322,8 @@ function initializeVisualsApp() {
       );
 
       float clump_noise_val = noise(uv * u_clump_density + u_time * u_clump_speed);
-      float clump_mask = smoothstep(u_clump_threshold - 0.1, u_clump_threshold + 0.1, clump_noise_val);
+      float clump_value = clump_noise_val * 0.5 + 0.5;
+      float clump_mask = smoothstep(u_clump_threshold - 0.1, u_clump_threshold + 0.1, clump_value);
 
       vec3 final_color = mix(vec3(0.0), flow_color, clump_mask);
       float grain = (rand(gl_FragCoord.xy) * 2.0 - 1.0) * u_grain_amount;


### PR DESCRIPTION
## Summary
- normalize the clump noise sample in the fragment shader to a 0-1 range
- drive the clump smoothstep mask with the normalized value so the threshold slider remains intuitive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6c23a884832381900eb38d18ea23