### PR TITLE
Rework visuals control layout to sit alongside canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,54 +192,58 @@
 
         <div class="app-shell" data-app="visuals">
           <div class="visuals-experience">
-            <div id="visualsControls" class="visuals-controls rounded-xl">
-              <h2 class="visuals-title">Visuals Controls</h2>
-              <div class="control-group">
-                <label for="speed">Animation Speed</label>
-                <input type="range" id="speed" min="0.1" max="2.0" step="0.05" value="1.0">
+            <div class="visuals-layout">
+              <div id="visualsControls" class="visuals-controls rounded-xl">
+                <h2 class="visuals-title">Visuals Controls</h2>
+                <div class="control-group">
+                  <label for="speed">Animation Speed</label>
+                  <input type="range" id="speed" min="0.1" max="2.0" step="0.05" value="1.0">
+                </div>
+                <div class="control-group">
+                  <label for="frequency">Flow Frequency</label>
+                  <input type="range" id="frequency" min="0.5" max="10.0" step="0.1" value="2.0">
+                </div>
+                <div class="control-group">
+                  <label for="amplitude">Color Amplitude</label>
+                  <input type="range" id="amplitude" min="0.1" max="5.0" step="0.05" value="1.0">
+                </div>
+                <div class="control-group">
+                  <label for="colorShift">Overall Color Shift</label>
+                  <input type="range" id="colorShift" min="0.0" max="1.0" step="0.01" value="0.0">
+                </div>
+                <div class="control-group">
+                  <label for="redColor">Red Base Color</label>
+                  <input type="range" id="redColor" min="0.0" max="1.0" step="0.01" value="0.5">
+                </div>
+                <div class="control-group">
+                  <label for="greenColor">Green Base Color</label>
+                  <input type="range" id="greenColor" min="0.0" max="1.0" step="0.01" value="0.5">
+                </div>
+                <div class="control-group">
+                  <label for="blueColor">Blue Base Color</label>
+                  <input type="range" id="blueColor" min="0.0" max="1.0" step="0.01" value="0.5">
+                </div>
+                <div class="control-group">
+                  <label for="grainAmount">Grain Amount</label>
+                  <input type="range" id="grainAmount" min="0.0" max="0.3" step="0.005" value="0.05">
+                </div>
+                <div class="control-group">
+                  <label for="clumpDensity">Clump Density</label>
+                  <input type="range" id="clumpDensity" min="0.5" max="5.0" step="0.05" value="1.5">
+                </div>
+                <div class="control-group">
+                  <label for="clumpSpeed">Clump Speed</label>
+                  <input type="range" id="clumpSpeed" min="0.0" max="1.0" step="0.01" value="0.3">
+                </div>
+                <div class="control-group">
+                  <label for="clumpThreshold">Clump Threshold</label>
+                  <input type="range" id="clumpThreshold" min="0.0" max="1.0" step="0.01" value="0.5">
+                </div>
               </div>
-              <div class="control-group">
-                <label for="frequency">Flow Frequency</label>
-                <input type="range" id="frequency" min="0.5" max="10.0" step="0.1" value="2.0">
-              </div>
-              <div class="control-group">
-                <label for="amplitude">Color Amplitude</label>
-                <input type="range" id="amplitude" min="0.1" max="5.0" step="0.05" value="1.0">
-              </div>
-              <div class="control-group">
-                <label for="colorShift">Overall Color Shift</label>
-                <input type="range" id="colorShift" min="0.0" max="1.0" step="0.01" value="0.0">
-              </div>
-              <div class="control-group">
-                <label for="redColor">Red Base Color</label>
-                <input type="range" id="redColor" min="0.0" max="1.0" step="0.01" value="0.5">
-              </div>
-              <div class="control-group">
-                <label for="greenColor">Green Base Color</label>
-                <input type="range" id="greenColor" min="0.0" max="1.0" step="0.01" value="0.5">
-              </div>
-              <div class="control-group">
-                <label for="blueColor">Blue Base Color</label>
-                <input type="range" id="blueColor" min="0.0" max="1.0" step="0.01" value="0.5">
-              </div>
-              <div class="control-group">
-                <label for="grainAmount">Grain Amount</label>
-                <input type="range" id="grainAmount" min="0.0" max="0.3" step="0.005" value="0.05">
-              </div>
-              <div class="control-group">
-                <label for="clumpDensity">Clump Density</label>
-                <input type="range" id="clumpDensity" min="0.5" max="5.0" step="0.05" value="1.5">
-              </div>
-              <div class="control-group">
-                <label for="clumpSpeed">Clump Speed</label>
-                <input type="range" id="clumpSpeed" min="0.0" max="1.0" step="0.01" value="0.3">
-              </div>
-              <div class="control-group">
-                <label for="clumpThreshold">Clump Threshold</label>
-                <input type="range" id="clumpThreshold" min="0.0" max="1.0" step="0.01" value="0.5">
+              <div class="visuals-canvas-container">
+                <canvas id="visualsCanvas"></canvas>
               </div>
             </div>
-            <canvas id="visualsCanvas"></canvas>
           </div>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -261,7 +261,12 @@ function initializeVisualsApp() {
   }
 
   const startTime = performance.now();
-  const container = controlsDiv.parentElement;
+  const canvasContainer = visualsCanvas.parentElement;
+
+  if (!canvasContainer) {
+    console.warn('Visuals canvas container is not available.');
+    return;
+  }
 
   const vertexShader = `
     void main() {
@@ -349,8 +354,8 @@ function initializeVisualsApp() {
 
   const uniforms = {
     u_time: { value: 0.0 },
-    u_resolution_x: { value: container.clientWidth || window.innerWidth },
-    u_resolution_y: { value: container.clientHeight || window.innerHeight },
+    u_resolution_x: { value: canvasContainer.clientWidth || window.innerWidth },
+    u_resolution_y: { value: canvasContainer.clientHeight || window.innerHeight },
     u_speed: { value: parseFloat(controls.speed?.value || '1.0') },
     u_frequency: { value: parseFloat(controls.frequency?.value || '2.0') },
     u_amplitude: { value: parseFloat(controls.amplitude?.value || '1.0') },
@@ -367,7 +372,8 @@ function initializeVisualsApp() {
   const scene = new THREERef.Scene();
   const camera = new THREERef.PerspectiveCamera(
     75,
-    (container.clientWidth || window.innerWidth) / (container.clientHeight || window.innerHeight),
+    (canvasContainer.clientWidth || window.innerWidth) /
+      (canvasContainer.clientHeight || window.innerHeight),
     0.1,
     1000
   );
@@ -386,8 +392,8 @@ function initializeVisualsApp() {
   scene.add(mesh);
 
   const updateRendererSize = () => {
-    const width = container.clientWidth || window.innerWidth;
-    const height = container.clientHeight || window.innerHeight;
+    const width = canvasContainer.clientWidth || window.innerWidth;
+    const height = canvasContainer.clientHeight || window.innerHeight;
     renderer.setSize(width, height, false);
     uniforms.u_resolution_x.value = width;
     uniforms.u_resolution_y.value = height;

--- a/styles.css
+++ b/styles.css
@@ -386,8 +386,23 @@ body.app-open .home-view {
   flex: 1;
   background: #000;
   border-radius: 24px;
-  overflow: hidden;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.6);
+  padding: 28px;
+  display: flex;
+}
+
+.visuals-layout {
+  display: flex;
+  gap: 28px;
+  width: 100%;
+  align-items: stretch;
+}
+
+.visuals-canvas-container {
+  position: relative;
+  flex: 1;
+  border-radius: 18px;
+  overflow: hidden;
 }
 
 .visuals-experience canvas {
@@ -399,11 +414,7 @@ body.app-open .home-view {
 }
 
 .visuals-controls {
-  position: absolute;
-  top: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: min(420px, calc(100% - 40px));
+  position: relative;
   padding: 24px;
   background: rgba(0, 0, 0, 0.7);
   border: 1px solid rgba(99, 102, 241, 0.4);
@@ -413,11 +424,12 @@ body.app-open .home-view {
   gap: 16px;
   box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
   transition: opacity 0.3s ease;
+  flex: 0 0 320px;
+  max-width: min(360px, 100%);
 }
 
 .visuals-controls.hidden-controls {
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 .visuals-title {
@@ -941,8 +953,24 @@ body.theme-cyberpunk {
     min-height: 320px;
   }
 
+  .visuals-experience {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 1200px) {
+  .visuals-layout {
+    flex-direction: column;
+  }
+
   .visuals-controls {
-    top: 16px;
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .visuals-canvas-container {
+    min-height: 480px;
   }
 }
 
@@ -970,10 +998,11 @@ body.theme-cyberpunk {
   }
 
   .visuals-controls {
-    position: relative;
-    left: auto;
-    transform: none;
-    width: 100%;
+    margin-bottom: 12px;
+  }
+
+  .visuals-canvas-container {
+    min-height: 420px;
   }
 }
 


### PR DESCRIPTION
## Summary
- restructure the visuals shell markup so the controls panel and canvas sit as flex siblings
- update the visuals styles to place the controls next to the canvas with responsive fallbacks
- adjust the visuals initialization logic to size the renderer against the new canvas container

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e425b2cb6c8323b060b9b6ac11fc48